### PR TITLE
builder: Expose ssh_key_id setting (fixes: #19).

### DIFF
--- a/builder/digitalocean/builder.go
+++ b/builder/digitalocean/builder.go
@@ -31,7 +31,13 @@ var _ packersdk.Builder = new(Builder)
 func (b *Builder) ConfigSpec() hcldec.ObjectSpec { return b.config.FlatMapstructure().HCL2Spec() }
 
 func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
+
 	warnings, errs := b.config.Prepare(raws...)
+	if (b.config.SSHPrivateKeyFile != "" && b.config.SSHKeyID == 0) ||
+		(b.config.SSHPrivateKeyFile == "" && b.config.SSHKeyID != 0) {
+		errs = packersdk.MultiErrorAppend(errs,
+			fmt.Errorf("Both `ssh_key_id` and `ssh_private_key_file` must be set when one is."))
+	}
 	if errs != nil {
 		return nil, warnings, errs
 	}

--- a/builder/digitalocean/config.go
+++ b/builder/digitalocean/config.go
@@ -93,6 +93,13 @@ type Config struct {
 	// it is at behind a firewall, then communicators should use the private IP
 	// instead of the public IP. Before using this, private_networking should be enabled.
 	ConnectWithPrivateIP bool `mapstructure:"connect_with_private_ip" required:"false"`
+	// The ID of an existing SSH key on the DigitalOcean account. This should be
+	// used in conjunction with `ssh_private_key_file`. When excluded, an SSH key
+	// will be automatically generated and used to build the image.
+	SSHKeyID int `mapstructure:"ssh_key_id" required:"false"`
+	// The path to an SSH private key file cooresponding to an SSH public key on
+	// a DigitalOcean account. This should be used in conjunction with `ssh_key_id`.
+	SSHPrivateKeyFile string `mapstructure:"ssh_private_key_file" required:"false"`
 
 	ctx interpolate.Context
 }

--- a/builder/digitalocean/config.hcl2spec.go
+++ b/builder/digitalocean/config.hcl2spec.go
@@ -85,6 +85,7 @@ type FlatConfig struct {
 	Tags                      []string          `mapstructure:"tags" required:"false" cty:"tags" hcl:"tags"`
 	VPCUUID                   *string           `mapstructure:"vpc_uuid" required:"false" cty:"vpc_uuid" hcl:"vpc_uuid"`
 	ConnectWithPrivateIP      *bool             `mapstructure:"connect_with_private_ip" required:"false" cty:"connect_with_private_ip" hcl:"connect_with_private_ip"`
+	SSHKeyID                  *int              `mapstructure:"ssh_key_id" required:"false" cty:"ssh_key_id" hcl:"ssh_key_id"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -174,6 +175,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"tags":                         &hcldec.AttrSpec{Name: "tags", Type: cty.List(cty.String), Required: false},
 		"vpc_uuid":                     &hcldec.AttrSpec{Name: "vpc_uuid", Type: cty.String, Required: false},
 		"connect_with_private_ip":      &hcldec.AttrSpec{Name: "connect_with_private_ip", Type: cty.Bool, Required: false},
+		"ssh_key_id":                   &hcldec.AttrSpec{Name: "ssh_key_id", Type: cty.Number, Required: false},
 	}
 	return s
 }

--- a/builder/digitalocean/step_create_droplet.go
+++ b/builder/digitalocean/step_create_droplet.go
@@ -21,7 +21,11 @@ func (s *stepCreateDroplet) Run(ctx context.Context, state multistep.StateBag) m
 	client := state.Get("client").(*godo.Client)
 	ui := state.Get("ui").(packersdk.Ui)
 	c := state.Get("config").(*Config)
-	sshKeyId := state.Get("ssh_key_id").(int)
+
+	sshKeyId := c.SSHKeyID
+	if sshKeyId == 0 {
+		sshKeyId = state.Get("ssh_key_id").(int)
+	}
 
 	// Create the droplet based on configuration
 	ui.Say("Creating droplet...")

--- a/docs-partials/builder/digitalocean/Config-not-required.mdx
+++ b/docs-partials/builder/digitalocean/Config-not-required.mdx
@@ -52,4 +52,11 @@
   it is at behind a firewall, then communicators should use the private IP
   instead of the public IP. Before using this, private_networking should be enabled.
 
+- `ssh_key_id` (int) - The ID of an existing SSH key on the DigitalOcean account. This should be
+  used in conjunction with `ssh_private_key_file`. When excluded, an SSH key
+  will be automatically generated and used to build the image.
+
+- `ssh_private_key_file` (string) - The path to an SSH private key file cooresponding to an SSH public key on
+  a DigitalOcean account. This should be used in conjunction with `ssh_key_id`.
+
 <!-- End of code generated from the comments of the Config struct in builder/digitalocean/config.go; -->


### PR DESCRIPTION
In https://github.com/hashicorp/packer/pull/10856, we moved to using the SDK for handling the generation of SSH keys. This had the side effect of exposing a number of new SSH key related options that had never been supported by the DigitalOcean builder before, including `ssh_private_key_file`.

When setting `ssh_private_key_file`, no SSH key is automatically generated and no public key is uploaded to the DigitalOcean account. So `ssh_key_id` is never set to state leading to the panic in #19. 

This PR exposes  `ssh_key_id` so that it can be configured by users directly. It also validates that  `ssh_private_key_file` and `ssh_key_id` are both set if one is.

Closes #19 

