### PR TITLE
Update ENV VARS to match Terraform Digital Ocean Plugin

### DIFF
--- a/builder/digitalocean/builder.go
+++ b/builder/digitalocean/builder.go
@@ -41,6 +41,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		return nil, warnings, errs
 	}
 
+	if len(warnings) > 0 {
+		return nil, warnings, nil
+	}
+
 	return nil, nil, nil
 }
 

--- a/builder/digitalocean/builder.go
+++ b/builder/digitalocean/builder.go
@@ -56,6 +56,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		client.BaseURL = u
 	}
 
+	if b.config.depToken {
+		ui.Say("[WARN] The DIGITALOCEAN_API_TOKEN environment variable is deprecated " +
+			"and will produce an error in future versions of the DigitalOcean Packer plugin. " +
+			"Please use either DIGITALOCEAN_TOKEN or DIGITALOCEAN_ACCESS_TOKEN moving forward.")
+	}
+
 	if len(b.config.SnapshotRegions) > 0 {
 		opt := &godo.ListOptions{
 			Page:    1,

--- a/builder/digitalocean/builder.go
+++ b/builder/digitalocean/builder.go
@@ -41,11 +41,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		return nil, warnings, errs
 	}
 
-	if len(warnings) > 0 {
-		return nil, warnings, nil
-	}
-
-	return nil, nil, nil
+	return nil, warnings, nil
 }
 
 func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook) (packersdk.Artifact, error) {

--- a/builder/digitalocean/builder.go
+++ b/builder/digitalocean/builder.go
@@ -56,12 +56,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		client.BaseURL = u
 	}
 
-	if b.config.depToken {
-		ui.Say("[WARN] The DIGITALOCEAN_API_TOKEN environment variable is deprecated " +
-			"and will produce an error in future versions of the DigitalOcean Packer plugin. " +
-			"Please use either DIGITALOCEAN_TOKEN or DIGITALOCEAN_ACCESS_TOKEN moving forward.")
-	}
-
 	if len(b.config.SnapshotRegions) > 0 {
 		opt := &godo.ListOptions{
 			Page:    1,

--- a/builder/digitalocean/builder_acc_test.go
+++ b/builder/digitalocean/builder_acc_test.go
@@ -43,6 +43,9 @@ func testAccPreCheck(t *testing.T) bool {
 		v = os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")
 	}
 	if v == "" {
+		v = os.Getenv("DIGITALOCEAN_API_TOKEN")
+	}
+	if v == "" {
 		t.Fatal("DIGITALOCEAN_TOKEN or DIGITALOCEAN_ACCESS_TOKEN must be set for acceptance tests")
 		return true
 	}

--- a/builder/digitalocean/builder_acc_test.go
+++ b/builder/digitalocean/builder_acc_test.go
@@ -38,8 +38,12 @@ func testAccPreCheck(t *testing.T) bool {
 			acctest.TestEnvVar))
 		return true
 	}
-	if v := os.Getenv("DIGITALOCEAN_API_TOKEN"); v == "" {
-		t.Fatal("DIGITALOCEAN_API_TOKEN must be set for acceptance tests")
+	v := os.Getenv("DIGITALOCEAN_TOKEN")
+	if v == "" {
+		v = os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")
+	}
+	if v == "" {
+		t.Fatal("DIGITALOCEAN_TOKEN or DIGITALOCEAN_ACCESS_TOKEN must be set for acceptance tests")
 		return true
 	}
 	return false
@@ -47,7 +51,10 @@ func testAccPreCheck(t *testing.T) bool {
 
 func makeTemplateWithImageId(t *testing.T) string {
 	if os.Getenv(acctest.TestEnvVar) != "" {
-		token := os.Getenv("DIGITALOCEAN_API_TOKEN")
+		token := os.Getenv("DIGITALOCEAN_TOKEN")
+		if token == "" {
+			token = os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")
+		}
 		client := godo.NewClient(oauth2.NewClient(context.TODO(), &apiTokenSource{
 			AccessToken: token,
 		}))

--- a/builder/digitalocean/config.go
+++ b/builder/digitalocean/config.go
@@ -133,9 +133,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		}
 		if c.APIToken == "" {
 			c.APIToken = os.Getenv("DIGITALOCEAN_API_TOKEN")
-			warns = append(warns, "The DIGITALOCEAN_API_TOKEN environment variable is deprecated "+
-				"and will produce an error in future versions of the DigitalOcean Packer plugin. "+
-				"Please use either DIGITALOCEAN_TOKEN or DIGITALOCEAN_ACCESS_TOKEN moving forward.")
+			if c.APIToken != "" {
+				warns = append(warns, "The DIGITALOCEAN_API_TOKEN environment variable is deprecated "+
+					"and will produce an error in future versions of the DigitalOcean Packer plugin. "+
+					"Please use either DIGITALOCEAN_TOKEN or DIGITALOCEAN_ACCESS_TOKEN moving forward.")
+			}
 		}
 	}
 	if c.APIURL == "" {

--- a/builder/digitalocean/config.go
+++ b/builder/digitalocean/config.go
@@ -26,8 +26,6 @@ type Config struct {
 	// can also be specified via environment variable DIGITALOCEAN_TOKEN, DIGITALOCEAN_ACCESS_TOKEN, or DIGITALOCEAN_API_TOKEN if
 	// set. DIGITALOCEAN_API_TOKEN will be deprecated in a future release in favor of DIGITALOCEAN_TOKEN or DIGITALOCEAN_ACCESS_TOKEN.
 	APIToken string `mapstructure:"api_token" required:"true"`
-	// DepToken is a flag denoting the use of the deprecated API token ENV VAR
-	depToken bool
 	// Non standard api endpoint URL. Set this if you are
 	// using a DigitalOcean API compatible service. It can also be specified via
 	// environment variable DIGITALOCEAN_API_URL.
@@ -135,7 +133,6 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		}
 		if c.APIToken == "" {
 			c.APIToken = os.Getenv("DIGITALOCEAN_API_TOKEN")
-			c.depToken = true
 			warns = append(warns, "The DIGITALOCEAN_API_TOKEN environment variable is deprecated "+
 				"and will produce an error in future versions of the DigitalOcean Packer plugin. "+
 				"Please use either DIGITALOCEAN_TOKEN or DIGITALOCEAN_ACCESS_TOKEN moving forward.")

--- a/builder/digitalocean/config.go
+++ b/builder/digitalocean/config.go
@@ -123,7 +123,10 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	// Defaults
 	if c.APIToken == "" {
 		// Default to environment variable for api_token, if it exists
-		c.APIToken = os.Getenv("DIGITALOCEAN_API_TOKEN")
+		c.APIToken = os.Getenv("DIGITALOCEAN_TOKEN")
+		if c.APIToken == "" {
+			c.APIToken = os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")
+		}
 	}
 	if c.APIURL == "" {
 		c.APIURL = os.Getenv("DIGITALOCEAN_API_URL")

--- a/builder/digitalocean/config.go
+++ b/builder/digitalocean/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 	Comm                communicator.Config `mapstructure:",squash"`
 	// The client TOKEN to use to access your account. It
-	// can also be specified via environment variable DIGITALOCEAN_API_TOKEN, if
+	// can also be specified via environment variable DIGITALOCEAN_TOKEN or DIGITALOCEAN_ACCESS_TOKEN, if
 	// set.
 	APIToken string `mapstructure:"api_token" required:"true"`
 	// Non standard api endpoint URL. Set this if you are

--- a/docs/post-processors/digitalocean-import.mdx
+++ b/docs/post-processors/digitalocean-import.mdx
@@ -52,7 +52,8 @@ Required:
 
 - `api_token` (string) - A personal access token used to communicate with
   the DigitalOcean v2 API. This may also be set using the
-  `DIGITALOCEAN_TOKEN or DIGITALOCEAN_ACCESS_TOKEN` environmental variables.
+  `DIGITALOCEAN_TOKEN` or `DIGITALOCEAN_ACCESS_TOKEN` environmental variables.
+  `DIGITALOCEAN_API_TOKEN` is acceptable but will be deprecated in a future release.
 
 - `spaces_key` (string) - The access key used to communicate with Spaces.
   This may also be set using the `DIGITALOCEAN_SPACES_ACCESS_KEY`

--- a/docs/post-processors/digitalocean-import.mdx
+++ b/docs/post-processors/digitalocean-import.mdx
@@ -52,7 +52,7 @@ Required:
 
 - `api_token` (string) - A personal access token used to communicate with
   the DigitalOcean v2 API. This may also be set using the
-  `DIGITALOCEAN_API_TOKEN` environmental variable.
+  `DIGITALOCEAN_TOKEN or DIGITALOCEAN_ACCESS_TOKEN` environmental variables.
 
 - `spaces_key` (string) - The access key used to communicate with Spaces.
   This may also be set using the `DIGITALOCEAN_SPACES_ACCESS_KEY`

--- a/post-processor/digitalocean-import/post-processor.go
+++ b/post-processor/digitalocean-import/post-processor.go
@@ -97,7 +97,10 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	}
 
 	if p.config.APIToken == "" {
-		p.config.APIToken = os.Getenv("DIGITALOCEAN_API_TOKEN")
+		p.config.APIToken = os.Getenv("DIGITALOCEAN_TOKEN")
+		if p.config.APIToken == "" {
+			p.config.APIToken = os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")
+		}
 	}
 
 	if p.config.ObjectName == "" {

--- a/post-processor/digitalocean-import/post-processor.go
+++ b/post-processor/digitalocean-import/post-processor.go
@@ -98,9 +98,12 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 
 	if p.config.APIToken == "" {
 		p.config.APIToken = os.Getenv("DIGITALOCEAN_TOKEN")
-		if p.config.APIToken == "" {
-			p.config.APIToken = os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")
-		}
+	}
+	if p.config.APIToken == "" {
+		p.config.APIToken = os.Getenv("DIGITALOCEAN_ACCESS_TOKEN")
+	}
+	if p.config.APIToken == "" {
+		p.config.APIToken = os.Getenv("DIGITALOCEAN_API_TOKEN")
 	}
 
 	if p.config.ObjectName == "" {


### PR DESCRIPTION
This is a relatively small change. This updates the environment variable from `DIGITALOCEAN_API_TOKEN` to either `DIGITALOCEAN_TOKEN` or `DIGITALOCEAN_ACCESS_TOKEN`. These two environment variables are used in the Terraform plugin for Digital Ocean as well. As referenced in issue #24 , this makes any CI/CD pipelines that use both the Packer plugin and the Terraform plugin simpler from a variables standpoint.
I tested both ENV VARS with my DO account and token, both created images.

Closes #24 
